### PR TITLE
Bump up default Mosquitto version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG MOSQUITTO_VERSION=1.4.12
+ARG MOSQUITTO_VERSION=1.6.15
 FROM eclipse-mosquitto:${MOSQUITTO_VERSION}
 
 # Install Tcl to be able to run the slicing script, and the root certificates


### PR DESCRIPTION
### This Pull Request is associated with card(s) URL(s):

[API-118](https://vocovo.atlassian.net/browse/API-118)

### Brief summary of the problem/need for this work:

The default version used by the docker-mosquitto image is too old. We need to have a newer default version of Mosquitto to use.

We also need to be able to specify what version of Mosquitto we want to use.

### Detail of how this Pull Request solves the problem/need:

Default version updated to `1.6.15` in reference to this [Slack Thread](https://vocovo.slack.com/archives/C03A6Q1TS72/p1669717129563089).

We don't need to do anything to specify the version of Mosquitto we want to use for the image since it already accepts a Docker ARG `MOSQUITTO_VERSION` which we can specify upon build.

### Notes to reviewers:

- It seems that the original image supports automatic builds and similar. Do we need this or is it enough that we build what image we want?
  - Personal take: I think it's enough to just have the version we need and build the docker-mosquitto image as needed.
- This is the simplest solution that I can think of. If there is a better way, please inform me.