### PR TITLE
Add Docker image build pipeline

### DIFF
--- a/.github/workflow/build-image.yml
+++ b/.github/workflow/build-image.yml
@@ -1,0 +1,27 @@
+name: Docker Image Builder
+run-name: Image built by @${{ github.actor }}
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        # Build Push Action @ version 3
+        uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
+        with:
+          push: true
+          tags: |
+            vocovo/docker-mosquitto:latest
+            vocovo/docker-mosquitto:${{ github.sha }}
+            vocovo/docker-mosquitto:${{ github.ref_name }}


### PR DESCRIPTION
### This Pull Request is associated with card(s) URL(s):

NA

### Brief summary of the problem/need for this work:

Automated Docker image build does not exist for this repo. It would improve DX for other repos (e.g. edge-broker) if a Docker image is readily accessible.

### Detail of how this Pull Request solves the problem/need:

Implement a build pipeline using `build-push-action` @ v3. A lot of the steps are similar with what we have with other repos (i.e. local-api)

### Notes to reviewers:

e.g:

- I've tried to use a SHA instead of a version for `build-push-action` to tie it with that particular release
- Should I add additional steps, tags, or branches to the action?

