### PR TITLE
Add build push Docker image workflow

### DIFF
--- a/.github/workflows/build-image-on-push-to-main.yml
+++ b/.github/workflows/build-image-on-push-to-main.yml
@@ -1,0 +1,28 @@
+name: 'Build image on push to master'
+run-name: Build image on push to master by @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_image:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: |
+            "vocovo/docker-mosquitto:${{ github.sha }}"
+            "vocovo/docker-mosquitto:latest"


### PR DESCRIPTION
>  **⚠️ Remove branch `feature/API-337` to push targets before merging. This is for test only ⚠️**

### This Pull Request is associated with card(s) URL(s):

[API-337](https://vocovo.atlassian.net/browse/API-337)

### Brief summary of the problem/need for this work:

We need a Docker image CI build pipeline to progress our work of making our fork of docker-mosquitto fit for production deployment.

### Detail of how this Pull Request solves the problem/need:

This PR adds a basic Docker build-push action which runs on merge to main.

### Notes to reviewers:

- This work is required for site-broker image build pipeline


[API-337]: https://vocovo.atlassian.net/browse/API-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ