### PR TITLE
Fix ref_name access in docker-image-tag step

### DIFF
--- a/.github/workflows/build-versioned-image.yaml
+++ b/.github/workflows/build-versioned-image.yaml
@@ -30,6 +30,7 @@ jobs:
         run: |
           sha_short=$(git rev-parse --short HEAD)
           timestamp=$(date +'%Y%m%d_%H%M%S')
+          ref="${{ steps.github-ref-name.outputs.ref }}"
           sha_tag="${ref}-${sha_short}"
           timestamp_tag="${ref}-${timestamp}"
           echo "Docker image tags are ${sha_tag} and ${timestamp_tag}"


### PR DESCRIPTION
### This Pull Request is associated with card(s) URL(s):

[VOC-4594]

### Brief summary of the problem/need for this work:
Create Docker image workflow fails due to an erroneous variable access.

### Detail of how this Pull Request solves the problem/need:

Patches incorrect access of `ref` in **docker-image-tag** step.

### Notes to reviewers:
N.A.

[VOC-4594]: https://vocovo.atlassian.net/browse/VOC-4594